### PR TITLE
Feature/add codeowners pr template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @TDT4290-SDG-Ontology/maintainers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Related Issue
+Closes #ID
+
+## Proposed changes
+- change 1
+- change 2
+
+## Additional info
+- any additional information or context 
+
+## How has this been tested?
+- [ ] Write test
+
+## Checklist
+- [ ] Tests
+- [ ] Documentation
+
+## Screenshots (if appropriate):

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Related Issue
-Closes #ID
+Closes `link to Trello issue`
 
 ## Proposed changes
 - change 1


### PR DESCRIPTION
## Related Issue
Closes https://trello.com/c/L57Mkt3V

## Proposed changes
- Add PR template (this one :))
- Add Codeowners file which will make the Maintainers team the codeowners of the repository (this comes with some benefits regarding automatic code reviews) 
- 
## How has this been tested?
- [x] Used these in previous repos. Will be tested when this is merged into `main`. 

## Checklist
- [x] Tests
- [x] Documentation

## Screenshots (if appropriate):