### PR TITLE
Add key to municipality buttons

### DIFF
--- a/frontend/src/components/molecules/MunicipalityList.tsx
+++ b/frontend/src/components/molecules/MunicipalityList.tsx
@@ -39,7 +39,7 @@ const MunicipalityList: React.FC = () => {
       <SimpleGrid columns={3} spacing="10">
         {municipalities &&
           municipalities.map((mun) => (
-            <MunicipalityButton municipality={mun} url={`/gdc/view/${mun.code}`} />
+            <MunicipalityButton key={mun.code} municipality={mun} url={`/gdc/view/${mun.code}`} />
           ))}
       </SimpleGrid>
     </Stack>

--- a/frontend/src/components/pages/GDCViewMunicipality.tsx
+++ b/frontend/src/components/pages/GDCViewMunicipality.tsx
@@ -132,6 +132,7 @@ const ViewMunicipality: React.FC = () => {
                     {similarMunicipalities &&
                       similarMunicipalities.map((mun) => (
                         <MunicipalityButton
+                          key={mun.code}
                           municipality={mun}
                           url={`/gdc/compare/${municipality}/${mun.code}`}
                         />


### PR DESCRIPTION
## Related Issue
Fixes issue caused by reworking municipality buttons and not adding a key.

React complains when there's no key for some elements with siblings. This fixes those errors associated with the rework done to the municipality buttons.

## Proposed changes
- Adds key to MunicipalityButtons

## Additional info
- any additional information or context 

## How has this been tested?
- [x] Write test

## Checklist
- [x] Tests
- [x] Documentation

## Screenshots (if appropriate):