### PR TITLE
Containerization bugfix

### DIFF
--- a/backend/database/graphdb.Dockerfile
+++ b/backend/database/graphdb.Dockerfile
@@ -6,4 +6,5 @@ EXPOSE 7200
 RUN mkdir -p /opt/graphdb/dist/conf
 COPY conf/ /opt/graphdb/dist/conf
 COPY ontology/ /opt/graphdb/home/ontology
+ENV GDB_JAVA_OPTS="-Dgraphdb.license.file=/opt/graphdb/dist/conf/graphdb.license"
 RUN /opt/graphdb/dist/bin/loadrdf -c /opt/graphdb/dist/conf/TK_SDG-config.ttl -m parallel /opt/graphdb/home/ontology --force

--- a/backend/docker-compose-backend.yml
+++ b/backend/docker-compose-backend.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: 'graphdb.Dockerfile'
     ports:
       - '7200:7200'
+    command: '/opt/graphdb/dist/bin/loadrdf -c /opt/graphdb/dist/conf/TK_SDG-config.ttl -m parallel /opt/graphdb/home/ontology'
   api:
     depends_on: ['graphdb']
     build:

--- a/backend/docker-compose-db.yml
+++ b/backend/docker-compose-db.yml
@@ -7,3 +7,4 @@ services:
       dockerfile: 'graphdb.Dockerfile'
     ports:
       - '7200:7200'
+    command: '/opt/graphdb/dist/bin/loadrdf -c /opt/graphdb/dist/conf/TK_SDG-config.ttl -m parallel /opt/graphdb/home/ontology'


### PR DESCRIPTION
Fixes breakage introduced at one point or another with building containers from scratch for containers from scratch for the backend.

A regression was introduced at some point where the configuration files for creating images from scratch for the backend ceased to load the license file correctly, and the loaded data was discarded due to a "non-existing" repository.  This resulted in a setup where there was no license loaded when graphdb started in workbench mode, no repositories set up, and no data loaded.

## Related Issue
None

## Proposed changes
- Adds loadrdf command to docker compose file
- Uses env-vars to set license file

## Additional info
- The RUN command creates a new layer, but the added command creates a new entry point. Somehow this fixes the problem.

## How has this been tested?
- [ ] Write test

## Checklist
- [ ] Tests
- [ ] Documentation

## Screenshots (if appropriate):