### PR TITLE
Bug/visualization feedback

### DIFF
--- a/frontend/src/components/molecules/GDCView.tsx
+++ b/frontend/src/components/molecules/GDCView.tsx
@@ -67,7 +67,7 @@ const GDCView: React.FC<GDCViewProps> = (props: GDCViewProps) => {
     municipalityGoalOverride,
     compareGoalOverride,
   } = props;
-  const WORST_COUNT = 10;
+  const WORST_COUNT = 15;
 
   const loadGDCOutput = async (muniCode: string, muniYear: number) => {
     if (muniYear === -1) return;


### PR DESCRIPTION
There was a bug when sorting for longest completion time, where "Never" wouldn't be part of the group of longest years.

## Related Issue
None

## Proposed changes
- Fix sorting
- Bump number of worst indicators to 15

## Additional info
- any additional information or context 

## How has this been tested?
- [ ] Write test

## Checklist
- [ ] Tests
- [ ] Documentation

## Screenshots (if appropriate):